### PR TITLE
Change for default tag

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}^]+";
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -22,7 +22,7 @@ public class PersonBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_FINANCIAL_INFO = "Good credit history";
     public static final String DEFAULT_SOCIAL_MEDIA_HANDLE = "alice_p";
-    public static final String DEFAULT_TAG = "friend";
+    public static final String DEFAULT_TAG = "^";
 
     private Name name;
     private Phone phone;


### PR DESCRIPTION
Implementation seems a little scuffed – default tag is now ^ symbol, which tag class has been modified to allow. 
Notably, when user inputs an add or edit command with t/^, it will be allowed and displayed as that tag, but otherwise, despite default tag ^ being used in the constructor of personBuilder class, ^ does not show up as a tag.