### PR TITLE
Add CSV export functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -18,7 +18,6 @@ public class ExportCommand extends Command {
             + ": Exports the address book in CSV format. "
             + "Example: " + COMMAND_WORD + " "
             + "format/csv";
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Export command not implemented yet";
     private final String format;
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -2,15 +2,16 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,46 +48,41 @@ public class ExportCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         String jsonFilePath = "data/addressbook.json";
-        String csvFilePath = "data/output.csv";
+        String csvFilePath = "data/addressbook.csv";
 
         try {
             List<Map<String, String>> jsonData = readAndParseJson(jsonFilePath);
             Set<String> headers = extractHeaders(jsonData);
             writeCsvFile(jsonData, headers, csvFilePath);
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return new CommandResult(SUCCESS_MESSAGE);
     }
 
-    private static List<Map<String, String>> readAndParseJson(String filePath) throws FileNotFoundException {
+    private static List<Map<String, String>> readAndParseJson(String filePath) throws IOException {
         List<Map<String, String>> jsonData = new ArrayList<>();
-        StringBuilder json = new StringBuilder();
+        String jsonString = new String(Files.readAllBytes(Paths.get(filePath)));
 
-        try (Scanner scanner = new Scanner(new File(filePath))) {
-            while (scanner.hasNextLine()) {
-                json.append(scanner.nextLine());
+        Pattern personPattern = Pattern.compile("\\{([^{}]+)}");
+        Matcher personMatcher = personPattern.matcher(jsonString);
+
+        while (personMatcher.find()) {
+            String personString = personMatcher.group(1);
+            Map<String, String> personData = new LinkedHashMap<>();
+            Pattern kvPattern = Pattern.compile("\"(\\w+)\"\\s*:\\s*\"([^\"]*)\"");
+            Matcher kvMatcher = kvPattern.matcher(personString);
+            while (kvMatcher.find()) {
+                String key = kvMatcher.group(1);
+                String value = kvMatcher.group(2);
+                personData.put(key, value);
+            }
+
+            if (!personData.isEmpty()) {
+                jsonData.add(personData);
             }
         }
 
-        // Regex to match key-value pairs
-        Pattern pattern = Pattern.compile("\"(\\w+)\"\\s*:\\s*\"([^\"]*)\"");
-        Matcher matcher = pattern.matcher(json);
-
-        Map<String, String> currentObject = new LinkedHashMap<>();
-        while (matcher.find()) {
-            String key = matcher.group(1);
-            String value = matcher.group(2);
-
-            if (key.equals("id") && !currentObject.isEmpty()) {
-                jsonData.add(currentObject);
-                currentObject = new LinkedHashMap<>();
-            }
-            currentObject.put(key, value);
-        }
-        if (!currentObject.isEmpty()) {
-            jsonData.add(currentObject);
-        }
         return jsonData;
     }
 
@@ -100,11 +96,8 @@ public class ExportCommand extends Command {
 
     private static void writeCsvFile(List<Map<String, String>> jsonData, Set<String> headers, String csvFilePath)
             throws FileNotFoundException {
-        try (PrintWriter writer = new PrintWriter(new File(csvFilePath))) {
-            // Write headers
+        try (PrintWriter writer = new PrintWriter(csvFilePath)) {
             writer.println(String.join(",", headers));
-
-            // Write data
             for (Map<String, String> row : jsonData) {
                 List<String> rowData = new ArrayList<>();
                 for (String header : headers) {

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -2,8 +2,22 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+
 
 /**
  * Exports the address book in a specified format.
@@ -18,11 +32,12 @@ public class ExportCommand extends Command {
             + ": Exports the address book in CSV format. "
             + "Example: " + COMMAND_WORD + " "
             + "format/csv";
+    public static final String SUCCESS_MESSAGE = "The address book has been exported in the specified format.";
     private final String format;
 
     /**
      * Constructs a ExportCommand instance (TODO: supplement JavaDoc stub)
-     * @param format the file format of the file to be exported (this should be ".csv")
+     * @param format the file format of the file to be exported (this should be "csv")
      */
     public ExportCommand(String format) {
         requireAllNonNull(format);
@@ -31,7 +46,74 @@ public class ExportCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(String.format(MESSAGE_ARGUMENTS, format));
+        String jsonFilePath = "data/addressbook.json";
+        String csvFilePath = "data/output.csv";
+
+        try {
+            List<Map<String, String>> jsonData = readAndParseJson(jsonFilePath);
+            Set<String> headers = extractHeaders(jsonData);
+            writeCsvFile(jsonData, headers, csvFilePath);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        return new CommandResult(SUCCESS_MESSAGE);
+    }
+
+    private static List<Map<String, String>> readAndParseJson(String filePath) throws FileNotFoundException {
+        List<Map<String, String>> jsonData = new ArrayList<>();
+        StringBuilder json = new StringBuilder();
+
+        try (Scanner scanner = new Scanner(new File(filePath))) {
+            while (scanner.hasNextLine()) {
+                json.append(scanner.nextLine());
+            }
+        }
+
+        // Regex to match key-value pairs
+        Pattern pattern = Pattern.compile("\"(\\w+)\"\\s*:\\s*\"([^\"]*)\"");
+        Matcher matcher = pattern.matcher(json);
+
+        Map<String, String> currentObject = new LinkedHashMap<>();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String value = matcher.group(2);
+
+            if (key.equals("id") && !currentObject.isEmpty()) {
+                jsonData.add(currentObject);
+                currentObject = new LinkedHashMap<>();
+            }
+            currentObject.put(key, value);
+        }
+        if (!currentObject.isEmpty()) {
+            jsonData.add(currentObject);
+        }
+        return jsonData;
+    }
+
+    private static Set<String> extractHeaders(List<Map<String, String>> jsonData) {
+        Set<String> headers = new LinkedHashSet<>();
+        for (Map<String, String> row : jsonData) {
+            headers.addAll(row.keySet());
+        }
+        return headers;
+    }
+
+    private static void writeCsvFile(List<Map<String, String>> jsonData, Set<String> headers, String csvFilePath)
+            throws FileNotFoundException {
+        try (PrintWriter writer = new PrintWriter(new File(csvFilePath))) {
+            // Write headers
+            writer.println(String.join(",", headers));
+
+            // Write data
+            for (Map<String, String> row : jsonData) {
+                List<String> rowData = new ArrayList<>();
+                for (String header : headers) {
+                    String cellValue = row.getOrDefault(header, "").replace("\"", "\"\"");
+                    rowData.add("\"" + cellValue + "\"");
+                }
+                writer.println(String.join(",", rowData));
+            }
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -12,28 +15,30 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input commands and creates a new ExportCommand object.
  */
 public class ExportCommandParser implements Parser<ExportCommand> {
-    private static final Pattern EXPORT_COMMAND_FORMAT = Pattern.compile("(?i)(format/(?<format>\\S+))");
+    private static final Pattern EXPORT_COMMAND_FORMAT = Pattern.compile("format/(?<format>\\S+)");
+    private static final ArrayList<String> SUPPORTED_FORMATS = new ArrayList<>(List.of("csv"));
 
     /**
      * Parses the given {@code String} of arguments in the context of the ExportCommand
      * and returns an ExportCommand object for execution.
      * @throws ParseException if the user input does not conform to the expected format
      */
+    @Override
     public ExportCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         final Matcher matcher = EXPORT_COMMAND_FORMAT.matcher(args.trim());
-
         if (!matcher.matches()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
 
-        // Extract the format from the input
+        // Extract the format (e.g., "csv") from the input
         String format = matcher.group("format");
 
-        if ((format == null || format.isEmpty())) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
         return new ExportCommand(format);
     }
 }
+
+

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_ARGUMENTS;
+import static seedu.address.logic.commands.ExportCommand.SUCCESS_MESSAGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -14,11 +16,12 @@ import seedu.address.model.UserPrefs;
 
 public class ExportCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    @Test
-    public void execute() {
-        final String format = "csv";
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-        assertCommandFailure(new ExportCommand(format), model, String.format(MESSAGE_ARGUMENTS, format));
+    @Test
+    public void execute_export_success() {
+        CommandResult expectedCommandResult = new CommandResult(SUCCESS_MESSAGE);
+        assertCommandSuccess(new ExportCommand("csv"), model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -2,9 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.ExportCommand.MESSAGE_ARGUMENTS;
 import static seedu.address.logic.commands.ExportCommand.SUCCESS_MESSAGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+
+public class ExportCommandParserTest {
+    private ExportCommandParser parser = new ExportCommandParser();
+    @Test
+    public void parse_csvFormat_success() {
+        ExportCommand expectedCommand = new ExportCommand("csv"); // Pass just "csv"
+        assertParseSuccess(parser, "format/csv", expectedCommand); // Pass "format/csv" as input
+    }
+
+    @Test
+    public void parse_missingCompulsoryFormat_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, "  ", expectedMessage);
+    }
+
+}


### PR DESCRIPTION
This PR adds the CSV exporting logic to the `export` CLI function in BA€.

To transfer BA€'s data to a CSV file, `ExportCommand` reads and parses the data from `/data/AddressBook.json` into a list. Afterwards, the list is read into `/data/AddressBook.csv`.

Other matters we need to keep in view include:
1. writing tests to cover these changes
2. introducing a new feature that allows users to choose the export CSV file's name and location
3. linking the export functionality to the "Export to CSV" button in the GUI

AI declaration: some of the changes in this PR were made with the assistance of Claude.ai