### PR TITLE
Fix regression issues related to `export`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -23,6 +23,10 @@ import seedu.address.model.Model;
 /**
  * Exports the address book in a specified format.
  * Currently, BA€ can export the address book as a CSV file.
+ * The process of converting the JSON file to a CSV file is as follows:
+ * 1. Data is read from the JSON file and parsed into a List of Maps (readAndParseJSON).
+ * 2. The headers of the JSON file (e.g. name, phone) are extracted (extractHeaders).
+ * 3. The data and headers are then written to the CSV file (writeCsvFile).
  */
 public class ExportCommand extends Command {
     public static final String MESSAGE_ARGUMENTS = "Export: %1$s";

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -72,7 +72,9 @@ public class ExportCommandTest {
     public void readAndParseJson() throws IOException {
         String jsonContent = "{\"persons\":"
                 + "[{\"name\":\"Tan Ah Kow\",\"phone\":\"98765432\"},"
-                + "{\"name\":\"Chua Ah Lian\",\"phone\":\"87654321\"}]}";
+                + "{\"name\":\"Chua Ah Lian\","
+                + "\"address\":\"Blk 30 Lorong 3 Serangoon Gardens, #07-18\","
+                + "\"tags\":[{\"colleagues\" : null},{\"friends\" : null}]}]}";
         Path jsonPath = tempDir.resolve("test.json");
         Files.write(jsonPath, jsonContent.getBytes());
         List<Map<String, String>> result = ExportCommand.readAndParseJson(jsonPath.toString());
@@ -81,18 +83,23 @@ public class ExportCommandTest {
         assertEquals("Tan Ah Kow", result.get(0).get("name"));
         assertEquals("98765432", result.get(0).get("phone"));
         assertEquals("Chua Ah Lian", result.get(1).get("name"));
-        assertEquals("87654321", result.get(1).get("phone"));
+        assertEquals("Blk 30 Lorong 3 Serangoon Gardens, #07-18", result.get(1).get("address"));
+        assertEquals(
+                "{\"colleagues\":null}, {\"friends\":null}",
+                    result.get(1).get("tags"));
     }
 
     @Test
     public void extractHeaders() {
         List<Map<String, String>> jsonData = new ArrayList<>();
         jsonData.add(new LinkedHashMap<>(Map.of("name", "Siti", "phone", "65432109")));
-        jsonData.add(new LinkedHashMap<>(Map.of("name", "Kumar", "email", "kumar@kgoomail.com")));
+        jsonData.add(new LinkedHashMap<>(Map.of("name", "Kumar",
+                "email", "kumar@kgoomail.com",
+                "tags", "[{\"colleagues\" : null},{\"friends\" : null}]")));
         Set<String> headers = ExportCommand.extractHeaders(jsonData);
 
-        assertEquals(3, headers.size());
-        assertTrue(headers.containsAll(Arrays.asList("name", "phone", "email")));
+        assertEquals(4, headers.size());
+        assertTrue(headers.containsAll(Arrays.asList("name", "phone", "email", "tags")));
     }
 
     @Test


### PR DESCRIPTION
After the `tags` field in AddressBook.json was introduced, `ExportCommand.readAndParseJson` broke because its RegEx formulas did not account for array fields.

Since `readAndParseJson` broke, the JSON could not be parsed and its data could not be written to `AddressBook.csv`. As a result, invoking export format/csv in the CLI would create a blank `AddressBook.csv`.

Let's refactor the `readAndParseJson` function to account for tags while making the implementation more intuitive. The RegEx-first approach will be replaced by an implementation that uses the Jackson API to process JSON data. We will also update the tests for `readAndParseJson` and `extractHeaders` to account for the `tags` field.

Removing RegEx is our first step to reinforcing the robustness of the implementation. If we introduce more complex fields in the future, the RegEx patterns required to process AddressBook.json could become more complex and difficult to maintain. On the other hand, the Jackson API was designed to handle JSON files. In the context of this function, Jackson functions are easier to use, faster, and more flexible than a RegEx implementation.

Resolves #66.