### PR TITLE
Patch `tags` format in CSV export

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -150,8 +150,6 @@ public class ExportCommand extends Command {
                 }
                 writer.println(String.join(",", rowData));
             }
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -29,7 +29,7 @@ import seedu.address.model.Model;
  * 3. The data and headers are then written to the CSV file (writeCsvFile).
  */
 public class ExportCommand extends Command {
-    public static final String MESSAGE_ARGUMENTS = "Export: %1$s";
+    public static final int DISTANCE_TO_TAG = 6;
 
     public static final String COMMAND_WORD = "export";
 
@@ -78,7 +78,7 @@ public class ExportCommand extends Command {
         // Check if the string starts with { and ends with }
         if (tagString.startsWith("\"{") && tagString.endsWith("}\"")) {
             // Remove the outer braces
-            tagString = tagString.substring(6, tagString.length() - 1);
+            tagString = tagString.substring(DISTANCE_TO_TAG, tagString.length() - 1);
 
             // Split by : and take the first part
             String[] parts = tagString.split(":");
@@ -90,7 +90,6 @@ public class ExportCommand extends Command {
                 return trimmed;
             }
         }
-
         // If the format doesn't match, return the original string
         return tagString;
     }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -65,6 +65,36 @@ public class ExportCommand extends Command {
         return new CommandResult(SUCCESS_MESSAGE);
     }
 
+    /**
+     * Parses a single tag from its JSON representation to its CSV representation.
+     * e.g. {\n \"friends\" : null\n} -> friends
+     * @param tagString
+     * @return a single parsed tag
+     */
+    static String parseTags(String tagString) {
+        // Remove leading and trailing whitespace
+        tagString = tagString.trim();
+
+        // Check if the string starts with { and ends with }
+        if (tagString.startsWith("\"{") && tagString.endsWith("}\"")) {
+            // Remove the outer braces
+            tagString = tagString.substring(6, tagString.length() - 1);
+
+            // Split by : and take the first part
+            String[] parts = tagString.split(":");
+            if (parts.length > 0) {
+                // Trim and remove quotes from the tag name
+                String trimmed = parts[0].trim()
+                        .replaceAll("\"", "")
+                        .replaceAll("\\\\", "");
+                return trimmed;
+            }
+        }
+
+        // If the format doesn't match, return the original string
+        return tagString;
+    }
+
     static List<Map<String, String>> readAndParseJson(String filePath) throws IOException {
         List<Map<String, String>> jsonData = new ArrayList<>();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -87,7 +117,7 @@ public class ExportCommand extends Command {
                 } else if (value.isArray() && header.equals("tags")) {
                     List<String> tags = new ArrayList<>();
                     for (JsonNode tag : value) {
-                        tags.add(tag.toString());
+                        tags.add(parseTags(tag.toString()));
                     }
                     personInfo.put(header, String.join(", ", tags));
                 } else {
@@ -121,6 +151,8 @@ public class ExportCommand extends Command {
                 }
                 writer.println(String.join(",", rowData));
             }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -70,23 +70,45 @@ public class ExportCommandTest {
 
     @Test
     public void readAndParseJson() throws IOException {
-        String jsonContent = "{\"persons\":"
-                + "[{\"name\":\"Tan Ah Kow\",\"phone\":\"98765432\"},"
-                + "{\"name\":\"Chua Ah Lian\","
-                + "\"address\":\"Blk 30 Lorong 3 Serangoon Gardens, #07-18\","
-                + "\"tags\":[{\"colleagues\" : null},{\"friends\" : null}]}]}";
+        String jsonContent = "{\n"
+                + "  \"persons\" : [ {\n"
+                + "    \"name\" : \"Alex Yeoh\",\n"
+                + "    \"phone\" : \"87438807\",\n"
+                + "    \"email\" : \"alexyeoh@example.com\",\n"
+                + "    \"address\" : \"Blk 30 Geylang Street 29, #06-40\",\n"
+                + "    \"tags\" : [ \"{\\n  \\\"friends\\\" : null\\n}\" ],\n"
+                + "    \"financialInfo\" : \"Annual life insurance premium: $1,200\",\n"
+                + "    \"socialMediaHandle\" : \"alex_yeoh\"\n"
+                + "  }, {\n"
+                + "    \"name\" : \"Bernice Yu\",\n"
+                + "    \"phone\" : \"99272758\",\n"
+                + "    \"email\" : \"berniceyu@example.com\",\n"
+                + "    \"address\" : \"Blk 30 Lorong 3 Serangoon Gardens, #07-18\",\n"
+                + "    \"tags\" : [ \"{\\n  \\\"colleagues\\\" : null\\n}\", \"{\\n  \\\"friends\\\" : null\\n}\" ],\n"
+                + "    \"financialInfo\" : \"Income category: $60,000 - $80,000\",\n"
+                + "    \"socialMediaHandle\" : \"bernice_yu\"\n"
+                + "  }]\n"
+                + "}";
         Path jsonPath = tempDir.resolve("test.json");
         Files.write(jsonPath, jsonContent.getBytes());
         List<Map<String, String>> result = ExportCommand.readAndParseJson(jsonPath.toString());
 
         assertEquals(2, result.size());
-        assertEquals("Tan Ah Kow", result.get(0).get("name"));
-        assertEquals("98765432", result.get(0).get("phone"));
-        assertEquals("Chua Ah Lian", result.get(1).get("name"));
+        assertEquals("Alex Yeoh", result.get(0).get("name"));
+        assertEquals("87438807", result.get(0).get("phone"));
+        assertEquals("alexyeoh@example.com", result.get(0).get("email"));
+        assertEquals("Blk 30 Geylang Street 29, #06-40", result.get(0).get("address"));
+        assertEquals("friends", result.get(0).get("tags"));
+        assertEquals("Annual life insurance premium: $1,200", result.get(0).get("financialInfo"));
+        assertEquals("alex_yeoh", result.get(0).get("socialMediaHandle"));
+
+        assertEquals("Bernice Yu", result.get(1).get("name"));
+        assertEquals("99272758", result.get(1).get("phone"));
+        assertEquals("berniceyu@example.com", result.get(1).get("email"));
         assertEquals("Blk 30 Lorong 3 Serangoon Gardens, #07-18", result.get(1).get("address"));
-        assertEquals(
-                "{\"colleagues\":null}, {\"friends\":null}",
-                    result.get(1).get("tags"));
+        assertEquals("colleagues, friends", result.get(1).get("tags"));
+        assertEquals("Income category: $60,000 - $80,000", result.get(1).get("financialInfo"));
+        assertEquals("bernice_yu", result.get(1).get("socialMediaHandle"));
     }
 
     @Test
@@ -95,7 +117,7 @@ public class ExportCommandTest {
         jsonData.add(new LinkedHashMap<>(Map.of("name", "Siti", "phone", "65432109")));
         jsonData.add(new LinkedHashMap<>(Map.of("name", "Kumar",
                 "email", "kumar@kgoomail.com",
-                "tags", "[{\"colleagues\" : null},{\"friends\" : null}]")));
+                "tags", "[ \"{\\n  \\\"colleagues\\\" : null\\n}\", \"{\\n  \\\"friends\\\" : null\\n}\" ]")));
         Set<String> headers = ExportCommand.extractHeaders(jsonData);
 
         assertEquals(4, headers.size());

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.ExportCommand.SUCCESS_MESSAGE;
+import static seedu.address.logic.commands.ExportCommand.parseTags;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
@@ -66,6 +67,46 @@ public class ExportCommandTest {
 
         // different export format -> returns false
         assertFalse(standardCommand.equals(new ExportCommand(differentFormat)));
+    }
+
+    @Test
+    public void parseValidTag() {
+        String input = "\"{\n  \"neighbours\" : \"null\"\n}\"";
+        String expectedOutput = "neighbours";
+        String result = parseTags(input);
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void parseInvalidTag_NoBraces() {
+        String input = "\"friends\" : null";
+        String expectedOutput = "\"friends\" : null";
+        String result = parseTags(input);
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void parseEmptyString() {
+        String input = "";
+        String expectedOutput = "";
+        String result = parseTags(input);
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void parseMalformedTag() {
+        String input = "{\"friends\":}";
+        String expectedOutput = "{\"friends\":}";
+        String result = parseTags(input);
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void parseNoColonInTag() {
+        String input = "{\"friends\"}";
+        String expectedOutput = "{\"friends\"}";
+        String result = parseTags(input);
+        assertEquals(expectedOutput, result);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -78,7 +78,7 @@ public class ExportCommandTest {
     }
 
     @Test
-    public void parseInvalidTag_NoBraces() {
+    public void parseInvalidTagNoBraces() {
         String input = "\"friends\" : null";
         String expectedOutput = "\"friends\" : null";
         String result = parseTags(input);


### PR DESCRIPTION
Although the `export` function is able to export a CSV file to `data/AddressBook.csv`, the `tags` field has not been properly formatted. An example of the issue is depicted in the screenshot below.

<img width="1385" alt="Screenshot 2024-10-22 at 12 22 22 AM" src="https://github.com/user-attachments/assets/ea60c853-ee12-444f-a62f-8dddec000377">

Let's create a `parseTag` helper function in `ExportCommand.java` which helps `readAndParseJson` to trim off unnecessary characters (e.g. `null`, newline characters, carriage returns). We shall also modify the tests to accommodate the changes in `readAndParseJson`'s output.

After these changes are merged, `AddressBook.csv`'s `tags` fields should appear more human-readable (as seen below).
<img width="551" alt="Screenshot 2024-10-22 at 12 40 26 AM" src="https://github.com/user-attachments/assets/303cccd0-dd3b-436e-92b7-485e09d3a57c">
