### PR TITLE
Update DuplicatePhoneTagger and Related Files

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.handler.DuplicatePhoneTagger;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -44,6 +45,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
+    private static final DuplicatePhoneTagger duplicatePhoneTagger = new DuplicatePhoneTagger();
     private final Person toAdd;
 
     /**
@@ -63,6 +65,7 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
+        duplicatePhoneTagger.tagPhoneDuplicates(model);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.handler.DuplicatePhoneTagger;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -25,6 +26,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
+    private static final DuplicatePhoneTagger duplicatePhoneTagger = new DuplicatePhoneTagger();
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {
@@ -42,6 +44,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        duplicatePhoneTagger.tagPhoneDuplicates(model);
 
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/logic/handler/DuplicatePhoneTagger.java
+++ b/src/main/java/seedu/address/logic/handler/DuplicatePhoneTagger.java
@@ -22,14 +22,18 @@ public class DuplicatePhoneTagger {
     private final HashMap<Phone, Integer> phoneFrequencies = new HashMap<>();
 
     /**
-     * Uses the model to update the person list based on duplicate phone numbers
+     * Updates the model's person list based on duplicate phone numbers
      * @param model that represents the current state of the address book
      */
     public void tagPhoneDuplicates(Model model) {
         assert model != null : "Model must exist";
-        List<Person> persons = model.getFilteredPersonList();
-        updateFrequenciesOfPhones(persons);
-        updatePersonsList(model, persons);
+        try {
+            List<Person> persons = model.getFilteredPersonList();
+            updateFrequenciesOfPhones(persons);
+            updatePersonsList(model, persons);
+        } catch (AssertionError e) {
+            return;
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.handler.DuplicatePhoneTagger;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,7 +22,6 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private final DuplicatePhoneTagger duplicatePhoneTagger;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -36,7 +34,6 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        this.duplicatePhoneTagger = new DuplicatePhoneTagger();
     }
 
     public ModelManager() {
@@ -99,13 +96,11 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
-        duplicatePhoneTagger.tagPhoneDuplicates(this);
     }
 
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
-        duplicatePhoneTagger.tagPhoneDuplicates(this);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 


### PR DESCRIPTION
DuplicatePhoneTagger is now used in the following classes:
- Logic classes
  - AddCommand.java
  - DeleteCommand.java
  - EditCommand.java
- Non-logic classes
  - MainApp.java (To read the JSON in the event it contains duplicate phone numbers and it is the first time the AB sees it)
  - PersonCard.java (To give the tag an FXML ID for CSS purposes)

Used to be in:
- Logic classes
  - EditCommand.java
- Non-logic classes
  - ModelManager.java (Takes advantage of existing ModelManager#addPerson and ModelManager#removePerson methods at the cost of higher coupling)
  - MainApp.java (To read the JSON in the event it contains duplicate phone numbers and it is the first time the AB sees it)
  - PersonCard.java (To give the tag an FXML ID for CSS purposes)