### PR TITLE
Display Persons with null tag value when using advfilter

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AdvFilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvFilterCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
 /**
- * Sort the contact list based on tag names and values.
+ * Filters the contact list based on tag name, value and operator.
  */
 public class AdvFilterCommand extends Command {
 
@@ -73,7 +73,7 @@ public class AdvFilterCommand extends Command {
 
         Predicate<Person> predicate = person -> {
             boolean tagMatches = person.getTags().stream().anyMatch(tag -> tag.tagName.equalsIgnoreCase(tagName)
-                    && tag.tagValue != null ? compare(operator, tag, tagValue) : false);
+                    && (tag.tagValue != null ? compare(operator, tag, tagValue) : true));
             return tagMatches;
         };
 


### PR DESCRIPTION
Always display Persons with null tag value when using Advfilter since its behaviour should be an extension of Filter.
In other words, Persons with corresponding tag name will be displayed by default as a fallback if there is no tag value to compare against.

Please update UG according to above.

Closes #164 