### PR TITLE
Update export feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AdvFilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AdvFilterCommand.java
@@ -36,7 +36,7 @@ public class AdvFilterCommand extends Command {
     private final Operator operator;
 
     /**
-     * Class that handles Operator enum type used in SortCommand
+     * Class that handles Operator enum type used in AdvFilterCommand
      */
     public static enum Operator {
         GREATER_THAN(">"),
@@ -59,7 +59,7 @@ public class AdvFilterCommand extends Command {
     }
 
     /**
-     * Class that handles SortCommand
+     * Class that handles AdvFilterCommand
      */
     public AdvFilterCommand(String tagName, Operator operator, String tagValue) {
         this.tagName = tagName;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -91,7 +91,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case ExportCommand.COMMAND_WORD:
-            return new ExportCommand();
+            return new ExportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.ExportCommand.Format;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input commands and creates a new ExportCommand object.
+ */
+public class ExportCommandParser implements Parser<ExportCommand> {
+    private static final Pattern EXPORT_COMMAND_FORMAT = Pattern.compile("format\\\\(?<format>\\S+)");
+    private static final ArrayList<String> SUPPORTED_FORMATS = new ArrayList<>(List.of("csv", "txt"));
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ExportCommand
+     * and returns an ExportCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    @Override
+    public ExportCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        final Matcher matcher = EXPORT_COMMAND_FORMAT.matcher(args.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        // Extract the format (e.g., "csv") from the input
+        String format = matcher.group("format");
+
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+        Format formatType = ExportCommand.matchFormat(format);
+
+        if (formatType == null) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+        return new ExportCommand(formatType);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.ExportCommand.Format;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -79,14 +80,14 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_export() throws Exception {
-        // TODO: softcode "format/csv"
-        assertTrue(parser.parseCommand(ExportCommand.COMMAND_WORD + " format/csv") instanceof ExportCommand);
+        // TODO: softcode "format\csv"
+        assertTrue(parser.parseCommand(ExportCommand.COMMAND_WORD + " format\\csv") instanceof ExportCommand);
     }
 
     @Test
     public void parseCommand_exportWithValidCommand() throws Exception {
-        ExportCommand command = (ExportCommand) parser.parseCommand(ExportCommand.COMMAND_WORD + " format/csv");
-        assertEquals(new ExportCommand(), command);
+        ExportCommand command = (ExportCommand) parser.parseCommand(ExportCommand.COMMAND_WORD + " format\\csv");
+        assertEquals(new ExportCommand(Format.CSV), command);
     }
     @Test
     public void parseCommand_help() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.ExportCommand.Format;
+
+public class ExportCommandParserTest {
+    private ExportCommandParser parser = new ExportCommandParser();
+    @Test
+    public void parse_csvFormat_success() {
+        ExportCommand expectedCommand = new ExportCommand(Format.CSV);
+        assertParseSuccess(parser, "format\\csv", expectedCommand); // Pass "format\csv" as input
+    }
+
+    @Test
+    public void parse_txtFormat_success() {
+        ExportCommand expectedCommand = new ExportCommand(Format.TXT);
+        assertParseSuccess(parser, "format\\txt", expectedCommand); // Pass "format\txt" as input
+    }
+
+    @Test
+    public void parse_missingCompulsoryFormat_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, "  ", expectedMessage);
+    }
+
+}

--- a/test.csv
+++ b/test.csv
@@ -1,0 +1,4 @@
+name,phone,email
+"Siti","65432109",""
+"Kumar","","kumar@kgoomail.com"
+"Ahmad","32109876","kumar@kgoomail.com"


### PR DESCRIPTION
### Changes
- ExportCommandParser.java readded
- Export feature now supports txt file format
    - Enum class used to check for supported formats (csv, txt) and unsupported formats
    - Added writeFile method that either calls ExportCommand#writeCsvFile, ExportCommand#writeTxtFile or throws IllegalArgumentException depending on the format specified
- New test cases for ExportCommand and ExportCommandParser
- Modified test cases in AddressBookParserTest.java
- Minor JavaDoc adjustments
    - "SortCommand" in AdvFilterCommand changed to "AdvFilterCommand"