### PR TITLE
Flag invalid tag arguments

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -30,7 +30,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             if (tagName.isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
             } else if (!Tag.isValidTagName(tagName)) {
-                throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
             }
             tags.add(new Tag(tagName)); // Create Tag objects for each tag provided
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -105,18 +105,7 @@ public class ParserUtil {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
         if (trimmedTag.contains(":")) {
-            String[] tagKeyValue = trimmedTag.split(":");
-            // Account for the possibility that the tag is just a lone colon.
-            // i.e. edit 1 t\:
-            if (tagKeyValue.length == 0) {
-                throw new ParseException(Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY);
-            }
-            if (!Tag.isValidTagName(tagKeyValue[0])) {
-                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
-            }
-            if (!Tag.isValidTagName(tagKeyValue[1])) {
-                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
-            }
+            String[] tagKeyValue = getTagKeyValue(trimmedTag);
             return new Tag(tagKeyValue[0], tagKeyValue[1]);
         } else {
             if (!Tag.isValidTagName(trimmedTag)) {
@@ -125,6 +114,22 @@ public class ParserUtil {
             return new Tag(trimmedTag);
         }
 
+    }
+
+    private static String[] getTagKeyValue(String trimmedTag) throws ParseException {
+        String[] tagKeyValue = trimmedTag.split(":");
+        // Account for the possibility that the tag is just a lone colon.
+        // i.e. edit 1 t\:
+        if (tagKeyValue.length == 0) {
+            throw new ParseException(Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY);
+        }
+        if (!Tag.isValidTagName(tagKeyValue[0])) {
+            throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        }
+        if (!Tag.isValidTagName(tagKeyValue[1])) {
+            throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        }
+        return tagKeyValue;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -123,7 +123,13 @@ public class ParserUtil {
         if (tagKeyValue.length == 0) {
             throw new ParseException(Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY);
         }
+        if (tagKeyValue.length == 1) {
+            throw new ParseException(Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING);
+        }
         if (!Tag.isValidTagName(tagKeyValue[0])) {
+            if (tagKeyValue[0].isEmpty()) {
+                throw new ParseException(Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING);
+            }
             throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
         }
         if (!Tag.isValidTagName(tagKeyValue[1])) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -106,16 +106,21 @@ public class ParserUtil {
         String trimmedTag = tag.trim();
         if (trimmedTag.contains(":")) {
             String[] tagKeyValue = trimmedTag.split(":");
+            // Account for the possibility that the tag is just a lone colon.
+            // i.e. edit 1 t\:
+            if (tagKeyValue.length == 0) {
+                throw new ParseException(Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY);
+            }
             if (!Tag.isValidTagName(tagKeyValue[0])) {
-                throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
             }
             if (!Tag.isValidTagName(tagKeyValue[1])) {
-                throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
             }
             return new Tag(tagKeyValue[0], tagKeyValue[1]);
         } else {
             if (!Tag.isValidTagName(trimmedTag)) {
-                throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
             }
             return new Tag(trimmedTag);
         }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -35,7 +35,7 @@ public class SortCommandParser implements Parser<SortCommand> {
         String tag = matcher.group("tag");
         String sortOrder = matcher.group("sortOrder");
         if (!isValidTagName(tag)) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
         }
         if ((tag == null || tag.isEmpty())
                 || (sortOrder == null || sortOrder.isEmpty() || (!sortOrder.equalsIgnoreCase("ASC")

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -8,8 +8,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
-
-<<<<<<< flag-invalid-inputs-for-edit
     public static final String MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC = "Tag names should be alphanumeric";
     public static final String MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY = "Tag names cannot be empty.";
     public static final String MESSAGE_TAG_NAME_OR_VALUE_MISSING = "Tag name or value is missing";

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -11,6 +11,7 @@ public class Tag {
 
     public static final String MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC = "Tag names should be alphanumeric";
     public static final String MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY = "Tag names cannot be empty.";
+    public static final String MESSAGE_TAG_NAME_OR_VALUE_MISSING = "Tag name or value is missing";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}]+";
 
     public final String tagName;

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC = "Tag names should be alphanumeric";
+    public static final String MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY = "Tag names cannot be empty.";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}]+";
 
     public final String tagName;
@@ -22,7 +23,7 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidTagName(tagName), MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
         this.tagName = tagName;
         this.tagValue = null;
     }
@@ -36,8 +37,8 @@ public class Tag {
     public Tag(String tagName, String tagValue) {
         requireNonNull(tagName);
         requireNonNull(tagValue);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        checkArgument(isValidTagName(tagValue), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidTagName(tagName), MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        checkArgument(isValidTagName(tagValue), MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
         this.tagName = tagName;
         this.tagValue = tagValue;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -77,7 +77,7 @@ class JsonAdaptedTag {
     public Tag toModelType() throws IllegalValueException {
         Entry<String, String> entry = map.entrySet().iterator().next();
         if (!Tag.isValidTagName(entry.getKey())) {
-            throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
         }
         if (entry.getValue() != null && Tag.isValidTagName(entry.getValue())) {
             return new Tag(entry.getKey(), entry.getValue());

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -193,7 +193,7 @@ public class AddCommandParserTest {
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -89,23 +89,35 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC); // invalid tag
+        // invalid name
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
+        // invalid phone
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
+        // invalid email
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS);
+        // invalid address
+        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS);
+        // invalid tag
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        assertParseFailure(parser,
+                "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        assertParseFailure(parser,
+                "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        assertParseFailure(parser,
+                "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
+        assertParseFailure(parser,
+                "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -93,16 +93,16 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC); // invalid tag
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -37,7 +37,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_invalidTagFormat_throwsParseException() {
         assertParseFailure(parser, " n\\Alice t\\fr!end",
-                Tag.MESSAGE_CONSTRAINTS);
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -47,7 +47,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
@@ -304,7 +304,6 @@ public class ParserUtilTest {
         Index maxIndex = Index.fromOneBased(Integer.MAX_VALUE);
         assertEquals(maxIndex, ParserUtil.parseIndex(Integer.toString(Integer.MAX_VALUE)));
     }
-    
     @Test
     public void parseTag_decimalValue() throws Exception {
         String tagWithDecimalValue = "grade:8.5";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -303,7 +303,8 @@ public class ParserUtilTest {
     public void parseIndex_maxIntegerValue() throws Exception {
         Index maxIndex = Index.fromOneBased(Integer.MAX_VALUE);
         assertEquals(maxIndex, ParserUtil.parseIndex(Integer.toString(Integer.MAX_VALUE)));
-
+    }
+    
     @Test
     public void parseTag_decimalValue() throws Exception {
         String tagWithDecimalValue = "grade:8.5";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -304,6 +304,7 @@ public class ParserUtilTest {
         Index maxIndex = Index.fromOneBased(Integer.MAX_VALUE);
         assertEquals(maxIndex, ParserUtil.parseIndex(Integer.toString(Integer.MAX_VALUE)));
 
+    @Test
     public void parseTag_decimalValue() throws Exception {
         String tagWithDecimalValue = "grade:8.5";
         Tag expectedTag = new Tag("grade", "8.5");

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -304,11 +304,4 @@ public class ParserUtilTest {
         Index maxIndex = Index.fromOneBased(Integer.MAX_VALUE);
         assertEquals(maxIndex, ParserUtil.parseIndex(Integer.toString(Integer.MAX_VALUE)));
     }
-    @Test
-    public void parseTag_decimalValue() throws Exception {
-        String tagWithDecimalValue = "grade:8.5";
-        Tag expectedTag = new Tag("grade", "8.5");
-        assertEquals(expectedTag, ParserUtil.parseTag(tagWithDecimalValue));
-
-    }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -160,40 +160,35 @@ public class ParserUtilTest {
     public void parseTag_emptyKeyAndValue_throwsParseException() {
         String tagWithoutKeyAndValue = ":";
         assertThrows(ParseException.class,
-                Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY,
-                () -> ParserUtil.parseTag(tagWithoutKeyAndValue));
+                Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY, () -> ParserUtil.parseTag(tagWithoutKeyAndValue));
     }
 
     @Test
     public void parseTag_emptyKey_throwsParseException() {
         String tagWithEmptyKey = ":value";
         assertThrows(ParseException.class,
-                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING,
-                () -> ParserUtil.parseTag(tagWithEmptyKey));
+                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING, () -> ParserUtil.parseTag(tagWithEmptyKey));
     }
 
     @Test
     public void parseTag_invalidKey_throwsParseException() {
         String tagWithInvalidKey = "$key:value";
         assertThrows(ParseException.class,
-                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC,
-                () -> ParserUtil.parseTag(tagWithInvalidKey));
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC, () -> ParserUtil.parseTag(tagWithInvalidKey));
     }
 
     @Test
     public void parseTag_emptyValue_throwsParseException() {
         String tagWithEmptyValue = "key:";
         assertThrows(ParseException.class,
-                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING,
-                () -> ParserUtil.parseTag(tagWithEmptyValue));
+                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING, () -> ParserUtil.parseTag(tagWithEmptyValue));
     }
 
     @Test
     public void parseTag_invalidValue_throwsParseException() {
         String tagWithInvalidValue = "key:$value";
         assertThrows(ParseException.class,
-                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC,
-                () -> ParserUtil.parseTag(tagWithInvalidValue));
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC, () -> ParserUtil.parseTag(tagWithInvalidValue));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -156,8 +157,43 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTag_emptyKeyAndValue_throwsParseException() {
+        String tagWithoutKeyAndValue = ":";
+        assertThrows(ParseException.class,
+                Tag.MESSAGE_TAG_NAMES_CANNOT_BE_EMPTY,
+                () -> ParserUtil.parseTag(tagWithoutKeyAndValue));
+    }
+
+    @Test
+    public void parseTag_emptyKey_throwsParseException() {
+        String tagWithEmptyKey = ":value";
+        assertThrows(ParseException.class,
+                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING,
+                () -> ParserUtil.parseTag(tagWithEmptyKey));
+    }
+
+    @Test
+    public void parseTag_invalidKey_throwsParseException() {
+        String tagWithInvalidKey = "$key:value";
+        assertThrows(ParseException.class,
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC,
+                () -> ParserUtil.parseTag(tagWithInvalidKey));
+    }
+
+    @Test
+    public void parseTag_emptyValue_throwsParseException() {
+        String tagWithEmptyValue = "key:";
+        assertThrows(ParseException.class,
+                Tag.MESSAGE_TAG_NAME_OR_VALUE_MISSING,
+                () -> ParserUtil.parseTag(tagWithEmptyValue));
+    }
+
+    @Test
     public void parseTag_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG));
+        String tagWithInvalidValue = "key:$value";
+        assertThrows(ParseException.class,
+                Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC,
+                () -> ParserUtil.parseTag(tagWithInvalidValue));
     }
 
     @Test
@@ -255,5 +291,21 @@ public class ParserUtilTest {
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(tag1, tag2));
         Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag("friend"), new Tag("colleague")));
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseIndex_zero_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex("0"));
+    }
+
+    @Test
+    public void parseIndex_negativeNumber_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex("-1"));
+    }
+
+    @Test
+    public void parseIndex_maxIntegerValue() throws Exception {
+        Index maxIndex = Index.fromOneBased(Integer.MAX_VALUE);
+        assertEquals(maxIndex, ParserUtil.parseIndex(Integer.toString(Integer.MAX_VALUE)));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -29,7 +29,7 @@ public class SortCommandParserTest {
     @Test
     public void parse_invalidTagFormat_throwsParseException() {
         assertParseFailure(parser, "t\\n@me ASC",
-                String.format(Tag.MESSAGE_CONSTRAINTS));
+                String.format(Tag.MESSAGE_TAG_NAMES_SHOULD_BE_ALPHANUMERIC));
     }
     //Invalid Order
     @Test


### PR DESCRIPTION
- Resolves #125.
- Invalid inputs to the `tag` handler `t\` will now produce relevant error messages in the GUI. Examples of invalid inputs include tags with empty keys and/or values (e.g. `edit 1 t\:`, `edit 1 t\key:`, `edit 1 t\:value`). Relevant tests for these invalid inputs have been written.
- Tests for invalid indices (e.g. `edit 0 t\friends`, `edit -1 t\friends`) have also been added.