### PR TITLE
Allow decimals for tag values

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}]+";
+    public static final String VALIDATION_REGEX = "(\\p{Alpha}+|\\d+(\\.\\d+)?)";
 
     public final String tagName;
     public final String tagValue;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -244,7 +244,8 @@ public class ParserUtilTest {
         String tag1 = "priority:high";
         String tag2 = "status:open";
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(tag1, tag2));
-        Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag("priority", "high"), new Tag("status", "open")));
+        Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag("priority", "high"),
+                new Tag("status", "open")));
         assertEquals(expectedTagSet, actualTagSet);
     }
 
@@ -255,5 +256,12 @@ public class ParserUtilTest {
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(tag1, tag2));
         Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag("friend"), new Tag("colleague")));
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTag_decimalValue() throws Exception {
+        String tagWithDecimalValue = "grade:8.5";
+        Tag expectedTag = new Tag("grade", "8.5");
+        assertEquals(expectedTag, ParserUtil.parseTag(tagWithDecimalValue));
     }
 }


### PR DESCRIPTION
Resolves #204.

A future suggestion for `ParserUtil.java`: in `parseTag`, we should strip whitespace surrounding the tag's key and value before checking if they are valid.

A possible implementation would look like this:
```java
public static Tag parseTag(String tag) throws ParseException {
        ...
        String key = tagKeyValue[0].trim();
        String value = tagKeyValue[1].trim();

        if (!Tag.isValidTagName(key)) {
        ...
}
```
This will ensure that tags with identical keys and values will be recognised as identical even if they are surrounded by additional whitespace e.g. `grade:8.5` vs. `grade : 8.5` (additional note: the `parseTag_decimalValue()` test for `ParserUtil.java` will NOT pass if the argument of the expected tag is `"grade : 8.5"` or `"grade: 8.5"`. The argument must have no additional whitespace around the tag key and value i.e. `"grade:8.5"`). 

However, I have not implemented this change yet. This is because #213 has made changes to `parseTag` that should be merged first to prevent any merge conflicts with future modifications of `parseTag`.